### PR TITLE
Fix PDF generator footer style parentheses

### DIFF
--- a/backend/pdf_generator.py
+++ b/backend/pdf_generator.py
@@ -198,9 +198,18 @@ class PDFGenerator:
         
         generation_date = datetime.now().strftime("%d/%m/%Y às %H:%M")
         story.append(Spacer(1, 10))
-        story.append(Paragraph(f"Proposta gerada em {generation_date}", 
-                              ParagraphStyle(name='Footer', parent=self.styles['Normal'], 
-                                           fontSize=8, textColor=colors.grey, alignment=TA_CENTER)))
+        story.append(
+            Paragraph(
+                f"Proposta gerada em {generation_date}",
+                ParagraphStyle(
+                    name='Footer',
+                    parent=self.styles['Normal'],
+                    fontSize=8,
+                    textColor=colors.grey,
+                    alignment=TA_CENTER,
+                )
+            )
+        )
         
         # Gera o PDF
         doc.build(story)


### PR DESCRIPTION
## Summary
- fix unmatched parenthesis for footer style in PDF generator

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ae929a60c8327899d27b5a26658a7