### PR TITLE
Fix docs paths

### DIFF
--- a/README-DEPLOY.md
+++ b/README-DEPLOY.md
@@ -14,8 +14,8 @@
 3. Configure as seguintes opções:
    - **Framework Preset**: Create React App
    - **Root Directory**: ./
-   - **Build Command**: `cd frontend && npm run build`
-   - **Output Directory**: `frontend/build`
+   - **Build Command**: `npm run build`
+   - **Output Directory**: `build`
 
 ### 2. Via CLI
 
@@ -37,10 +37,8 @@ georural-pro/
 │   ├── upload-gnss.py     # Endpoint para upload GNSS
 │   ├── calculate-budget.py # Cálculo de orçamento
 │   └── generate-proposal-pdf.py # Geração de PDF
-├── frontend/              # React App
-│   ├── build/            # Arquivos buildados
-│   ├── src/              # Código fonte
-│   └── package.json
+├── src/                   # Código fonte React
+├── public/                # Arquivos estáticos
 ├── backend/              # Backend original (não usado na Vercel)
 └── vercel.json           # Configuração da Vercel
 ```

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ cd georural-pro
 2. Execute os scripts SQL em `supabase/`
 3. Configure `.env.local`:
 ```bash
-cp frontend/.env.example frontend/.env.local
+cp .env.example .env.local
 # Edite com suas chaves do Supabase
 ```
 
@@ -47,7 +47,7 @@ No painel da Vercel, adicione:
 
 ```bash
 # Instalar dependências
-cd frontend && npm install
+npm install
 
 # Iniciar desenvolvimento
 npm start
@@ -58,10 +58,10 @@ npm start
 ```
 georural-pro/
 ├── api/                 # Vercel Functions (Python)
-├── frontend/            # React App com shadcn/ui
+├── src/                 # Código React
+├── public/              # Arquivos estáticos
 ├── supabase/           # Scripts SQL do banco
 ├── vercel.json         # Configuração Vercel
-└── docs/               # Documentação
 ```
 
 ## 🔧 Solução de Problemas
@@ -131,7 +131,6 @@ MIT License - veja [LICENSE](LICENSE) para detalhes.
 
 - 📧 Email: suporte@georural.pro
 - 💬 Issues: [GitHub Issues](https://github.com/seu-usuario/georural-pro/issues)
-- 📖 Docs: [Documentação Completa](./docs/)
 
 ---
 

--- a/SUPABASE-SETUP.md
+++ b/SUPABASE-SETUP.md
@@ -50,7 +50,7 @@
 
 1. Copie o arquivo `.env.example` para `.env.local`:
    ```bash
-   cp frontend/.env.example frontend/.env.local
+   cp .env.example .env.local
    ```
 
 2. Edite o arquivo `.env.local` com suas chaves:
@@ -63,7 +63,6 @@
 
 1. Inicie o projeto:
    ```bash
-   cd frontend
    npm start
    ```
 

--- a/VERCEL-TROUBLESHOOTING.md
+++ b/VERCEL-TROUBLESHOOTING.md
@@ -14,8 +14,8 @@
    - **Framework Preset**: Create React App
    - **Root Directory**: `./` (deixe vazio)
    - **Build Command**: `npm run build`
-   - **Output Directory**: `frontend/build`
-   - **Install Command**: `npm install && cd frontend && npm install`
+   - **Output Directory**: `build`
+   - **Install Command**: `npm install`
 
 #### 2. Variáveis de Ambiente
 
@@ -35,16 +35,14 @@
 **Solução**: Certifique-se de que a estrutura está assim:
 ```
 georural-pro/
-├── package.json          # Na raiz (copiado do frontend)
+├── package.json          # Configuração do React
 ├── vercel.json           # Configuração da Vercel
 ├── api/                  # Vercel Functions
 │   ├── upload-gnss.py
 │   ├── calculate-budget.py
 │   └── generate-proposal-pdf.py
-├── frontend/             # React App
-│   ├── build/           # Gerado pelo npm run build
-│   ├── src/
-│   └── package.json
+├── src/                  # Código fonte React
+├── public/               # Arquivos estáticos
 └── supabase/            # Scripts SQL
 ```
 
@@ -68,7 +66,7 @@ vercel
 # Seguir instruções e configurar:
 # - Framework: Create React App
 # - Build Command: npm run build
-# - Output Directory: frontend/build
+# - Output Directory: build
 ```
 
 ## 🔍 Debug
@@ -84,7 +82,7 @@ vercel
 npm run build
 
 # Servir estaticamente
-npx serve frontend/build
+npx serve build
 
 # Deve funcionar em localhost:3000
 ```


### PR DESCRIPTION
## Summary
- update README instructions for src/public layout
- update deploy instructions for correct root build paths
- update troubleshooting guide for new structure
- tweak Supabase setup docs to match current paths

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b12ec62648327a5a93e1254cbb071